### PR TITLE
【残課題】Androidアプリのログイン時に読み込む証明書の取得に不備がある

### DIFF
--- a/Android/MyNumberCardAuth/app/src/main/java/com/example/mynumbercardidp/util/mynumber/JpkiUtils.kt
+++ b/Android/MyNumberCardAuth/app/src/main/java/com/example/mynumbercardidp/util/mynumber/JpkiUtils.kt
@@ -56,7 +56,7 @@ class JpkiUtils(private val reader: NfcReader) {
         val bodySize = ByteBuffer.wrap(header, 2, 2).short
 
         // 全体を読み込み、データを返却する
-        return readBinary(bodySize + headerSize)
+        return readBinary(headerSize + bodySize)
     }
 
     private fun readBinary(expectedSize: Int): ByteArray {

--- a/Android/MyNumberCardAuth/app/src/main/java/com/example/mynumbercardidp/util/mynumber/JpkiUtils.kt
+++ b/Android/MyNumberCardAuth/app/src/main/java/com/example/mynumbercardidp/util/mynumber/JpkiUtils.kt
@@ -53,10 +53,10 @@ class JpkiUtils(private val reader: NfcReader) {
         if (header.isEmpty()) { return byteArrayOf() }
 
         // 読み込んだデータから、データ全体量の格納部分を抽出
-        val sizeToRead = ByteBuffer.wrap(header, 2, 2).short
+        val bodySize = ByteBuffer.wrap(header, 2, 2).short
 
         // 全体を読み込み、データを返却する
-        return readBinary(sizeToRead + headerSize)
+        return readBinary(bodySize + headerSize)
     }
 
     private fun readBinary(expectedSize: Int): ByteArray {
@@ -64,7 +64,7 @@ class JpkiUtils(private val reader: NfcReader) {
 
         // 不足サイズ分が取り切れるまでREAD BINARYを繰り返す
         while (data.size < expectedSize) {
-            var currentData = reader.readBinary(expectedSize - data.size, data.size)
+            var currentData = reader.readBinary(expectedSize - data.size, data.size.toUShort())
             if (currentData.isEmpty()) { break }
             data += currentData
         }

--- a/Android/MyNumberCardAuth/app/src/main/java/com/example/mynumbercardidp/util/mynumber/JpkiUtils.kt
+++ b/Android/MyNumberCardAuth/app/src/main/java/com/example/mynumbercardidp/util/mynumber/JpkiUtils.kt
@@ -1,12 +1,12 @@
 package com.example.mynumbercardidp.util.mynumber
 
 import com.example.mynumbercardidp.util.hexToByteArray
-import com.example.mynumbercardidp.util.toHexString
+import java.nio.ByteBuffer
 
 class JpkiUtils(private val reader: NfcReader) {
     companion object {
         private const val logTag = "JpkiUtils"
-        private const val offset = 4 //読み込むべきサイズを取得するための情報部が格納されているバイト数
+        private const val headerSize = 4 //データサイズなどの情報部が格納されている先頭部のバイト数
     }
 
     fun lookupAuthPin(): Int {
@@ -49,13 +49,27 @@ class JpkiUtils(private val reader: NfcReader) {
         reader.selectEF(efid)
 
         // 読み込むべきサイズを取得するため、先頭4バイト取得
-        val header = reader.readBinary(offset)
+        val header = reader.readBinary(headerSize)
+        if (header.isEmpty()) { return byteArrayOf() }
+
         // 読み込んだデータから、データ全体量の格納部分を抽出
-        val sizeToReadHex = header.toHexString().substring(4,8)
-        val sizeToRead = Integer.parseInt(sizeToReadHex, 16) + offset
+        val sizeToRead = ByteBuffer.wrap(header, 2, 2).short
 
         // 全体を読み込み、データを返却する
-        return reader.readBinary(sizeToRead)
+        return readBinary(sizeToRead + headerSize)
+    }
+
+    private fun readBinary(expectedSize: Int): ByteArray {
+        var data = byteArrayOf()
+
+        // 不足サイズ分が取り切れるまでREAD BINARYを繰り返す
+        while (data.size < expectedSize) {
+            var currentData = reader.readBinary(expectedSize - data.size, data.size)
+            if (currentData.isEmpty()) { break }
+            data += currentData
+        }
+
+        return data
     }
 
     fun authSignature(nonce: ByteArray): ByteArray {

--- a/Android/MyNumberCardAuth/app/src/main/java/com/example/mynumbercardidp/util/mynumber/NfcReader.kt
+++ b/Android/MyNumberCardAuth/app/src/main/java/com/example/mynumbercardidp/util/mynumber/NfcReader.kt
@@ -94,8 +94,8 @@ class NfcReader(nfcTag: Tag) {
 
     fun readBinary(size: Int, offset: UShort = 0u): ByteArray {
         // オフセットの指定値を上位バイトと、下位バイトに変換
-        val p1 = (offset.toInt() shr 8).toByte()
-        val p2 = offset.toByte()
+        val p1 = ((offset.toULong() shr 8) and 255u).toByte()
+        val p2 = (offset.toULong() and 255u).toByte()
 
         val apduCommand = APDUCommand.apduCase2(0x00, 0xB0.toByte(), p1, p2, size)
         val (_, _, data) = transceiver(apduCommand)

--- a/Android/MyNumberCardAuth/app/src/main/java/com/example/mynumbercardidp/util/mynumber/NfcReader.kt
+++ b/Android/MyNumberCardAuth/app/src/main/java/com/example/mynumbercardidp/util/mynumber/NfcReader.kt
@@ -92,12 +92,13 @@ class NfcReader(nfcTag: Tag) {
         return Triple(0, 0, byteArrayOf())
     }
 
-    fun readBinary(size: Int): ByteArray {
-        val apduCommand = APDUCommand.apduCase2(0x00, 0xB0.toByte(), 0, 0, size)
-        val (sw1, sw2, data) = transceiver(apduCommand)
-        if (sw1 != 0x90.toByte() || sw2 != 0x00.toByte()) {
-            return byteArrayOf()
-        }
+    fun readBinary(size: Int, offset: Int = 0): ByteArray {
+        // オフセットの指定値を上位バイトと、下位バイトに変換
+        val p1 = (offset shr 8).toByte()
+        val p2 = (offset and 0xff).toByte()
+
+        val apduCommand = APDUCommand.apduCase2(0x00, 0xB0.toByte(), p1, p2, size)
+        val (_, _, data) = transceiver(apduCommand)
         return data
     }
 

--- a/Android/MyNumberCardAuth/app/src/main/java/com/example/mynumbercardidp/util/mynumber/NfcReader.kt
+++ b/Android/MyNumberCardAuth/app/src/main/java/com/example/mynumbercardidp/util/mynumber/NfcReader.kt
@@ -94,8 +94,8 @@ class NfcReader(nfcTag: Tag) {
 
     fun readBinary(size: Int, offset: UShort = 0u): ByteArray {
         // オフセットの指定値を上位バイトと、下位バイトに変換
-        val p1 = ((offset.toULong() shr 8) and 255u).toByte()
-        val p2 = (offset.toULong() and 255u).toByte()
+        val p1 = ((offset.toULong() shr 8) and 0xFFu).toByte()
+        val p2 = (offset.toULong() and 0xFFu).toByte()
 
         val apduCommand = APDUCommand.apduCase2(0x00, 0xB0.toByte(), p1, p2, size)
         val (_, _, data) = transceiver(apduCommand)

--- a/Android/MyNumberCardAuth/app/src/main/java/com/example/mynumbercardidp/util/mynumber/NfcReader.kt
+++ b/Android/MyNumberCardAuth/app/src/main/java/com/example/mynumbercardidp/util/mynumber/NfcReader.kt
@@ -92,10 +92,10 @@ class NfcReader(nfcTag: Tag) {
         return Triple(0, 0, byteArrayOf())
     }
 
-    fun readBinary(size: Int, offset: Int = 0): ByteArray {
+    fun readBinary(size: Int, offset: UShort = 0u): ByteArray {
         // オフセットの指定値を上位バイトと、下位バイトに変換
-        val p1 = (offset shr 8).toByte()
-        val p2 = (offset and 0xff).toByte()
+        val p1 = (offset.toInt() shr 8).toByte()
+        val p2 = offset.toByte()
 
         val apduCommand = APDUCommand.apduCase2(0x00, 0xB0.toByte(), p1, p2, size)
         val (_, _, data) = transceiver(apduCommand)


### PR DESCRIPTION
使用するデバイスによって一度で読み取れる証明書のサイズに制限がある場合があり、
証明書が正しく取得されない事象が発生したため、
読み取りたいサイズに達するまで、取得を繰り返すよう修正。