### PR TITLE
iOSのJWE暗号化対応

### DIFF
--- a/iOS/MyNumberCardAuth/MyNumberCardAuth.xcodeproj/project.pbxproj
+++ b/iOS/MyNumberCardAuth/MyNumberCardAuth.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		9F931D902AA6FE1A009BA06A /* TRETJapanNFCReader-MIFARE-IndividualNumber in Frameworks */ = {isa = PBXBuildFile; productRef = 9F931D8F2AA6FE1A009BA06A /* TRETJapanNFCReader-MIFARE-IndividualNumber */; };
 		9FCA69B32A4BEE24008AC285 /* NFCReadingForSignatureView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FCA69B22A4BEE24008AC285 /* NFCReadingForSignatureView.swift */; };
 		9FE5928D2A57E91B000C3569 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 9FE5928F2A57E91B000C3569 /* Localizable.strings */; };
+		9FF1B6F62AAD9E9200793DD6 /* JOSESwift in Frameworks */ = {isa = PBXBuildFile; productRef = 9FF1B6F52AAD9E9200793DD6 /* JOSESwift */; };
 		AD80228D29F0B402009EA409 /* MyNumberCardAuthApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD80228C29F0B402009EA409 /* MyNumberCardAuthApp.swift */; };
 		AD80228F29F0B402009EA409 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD80228E29F0B402009EA409 /* ContentView.swift */; };
 		AD80229129F0B403009EA409 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = AD80229029F0B403009EA409 /* Assets.xcassets */; };
@@ -44,7 +45,7 @@
 		9FCA69B22A4BEE24008AC285 /* NFCReadingForSignatureView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NFCReadingForSignatureView.swift; sourceTree = "<group>"; };
 		9FE5928E2A57E91B000C3569 /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/Localizable.strings; sourceTree = "<group>"; };
 		9FE592902A57E91F000C3569 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
-		9FF1B6F22AAD83FF00793DD6 /* MyNumberCardAuth.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = MyNumberCardAuth.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		9FF1B6F72AAD9EB100793DD6 /* MyNumberCardAuth.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = MyNumberCardAuth.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		AD80228C29F0B402009EA409 /* MyNumberCardAuthApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyNumberCardAuthApp.swift; sourceTree = "<group>"; };
 		AD80228E29F0B402009EA409 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; wrapsLines = 1; };
 		AD80229029F0B403009EA409 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -64,6 +65,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				9F931D902AA6FE1A009BA06A /* TRETJapanNFCReader-MIFARE-IndividualNumber in Frameworks */,
+				9FF1B6F62AAD9E9200793DD6 /* JOSESwift in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -83,7 +85,7 @@
 			children = (
 				AD80228B29F0B402009EA409 /* MyNumberCardAuth */,
 				AD80229D29F0B666009EA409 /* Frameworks */,
-				9FF1B6F22AAD83FF00793DD6 /* MyNumberCardAuth.app */,
+				9FF1B6F72AAD9EB100793DD6 /* MyNumberCardAuth.app */,
 			);
 			sourceTree = "<group>";
 		};
@@ -168,9 +170,10 @@
 			name = MyNumberCardAuth;
 			packageProductDependencies = (
 				9F931D8F2AA6FE1A009BA06A /* TRETJapanNFCReader-MIFARE-IndividualNumber */,
+				9FF1B6F52AAD9E9200793DD6 /* JOSESwift */,
 			);
 			productName = MyNumberCardAuth;
-			productReference = 9FF1B6F22AAD83FF00793DD6 /* MyNumberCardAuth.app */;
+			productReference = 9FF1B6F72AAD9EB100793DD6 /* MyNumberCardAuth.app */;
 			productType = "com.apple.product-type.application";
 		};
 /* End PBXNativeTarget section */
@@ -199,6 +202,8 @@
 			);
 			mainGroup = AD80228029F0B402009EA409;
 			packageReferences = (
+				9FF1B6F12AAD83C900793DD6 /* XCRemoteSwiftPackageReference "TRETJapanNFCReader" */,
+				9FF1B6F42AAD9E9200793DD6 /* XCRemoteSwiftPackageReference "JOSESwift" */,
 			);
 			productRefGroup = AD80228A29F0B402009EA409 /* Products */;
 			projectDirPath = "";
@@ -468,12 +473,25 @@
 				kind = branch;
 			};
 		};
+		9FF1B6F42AAD9E9200793DD6 /* XCRemoteSwiftPackageReference "JOSESwift" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/airsidemobile/JOSESwift.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.0.0;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
 		9F931D8F2AA6FE1A009BA06A /* TRETJapanNFCReader-MIFARE-IndividualNumber */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = "TRETJapanNFCReader-MIFARE-IndividualNumber";
+		};
+		9FF1B6F52AAD9E9200793DD6 /* JOSESwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 9FF1B6F42AAD9E9200793DD6 /* XCRemoteSwiftPackageReference "JOSESwift" */;
+			productName = JOSESwift;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/iOS/MyNumberCardAuth/MyNumberCardAuth.xcodeproj/project.pbxproj
+++ b/iOS/MyNumberCardAuth/MyNumberCardAuth.xcodeproj/project.pbxproj
@@ -45,7 +45,7 @@
 		9FCA69B22A4BEE24008AC285 /* NFCReadingForSignatureView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NFCReadingForSignatureView.swift; sourceTree = "<group>"; };
 		9FE5928E2A57E91B000C3569 /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/Localizable.strings; sourceTree = "<group>"; };
 		9FE592902A57E91F000C3569 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
-		9FF1B6F72AAD9EB100793DD6 /* MyNumberCardAuth.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = MyNumberCardAuth.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		9FF1B6F22AAD83FF00793DD6 /* MyNumberCardAuth.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = MyNumberCardAuth.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		AD80228C29F0B402009EA409 /* MyNumberCardAuthApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyNumberCardAuthApp.swift; sourceTree = "<group>"; };
 		AD80228E29F0B402009EA409 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; wrapsLines = 1; };
 		AD80229029F0B403009EA409 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -85,7 +85,7 @@
 			children = (
 				AD80228B29F0B402009EA409 /* MyNumberCardAuth */,
 				AD80229D29F0B666009EA409 /* Frameworks */,
-				9FF1B6F72AAD9EB100793DD6 /* MyNumberCardAuth.app */,
+				9FF1B6F22AAD83FF00793DD6 /* MyNumberCardAuth.app */,
 			);
 			sourceTree = "<group>";
 		};
@@ -173,7 +173,7 @@
 				9FF1B6F52AAD9E9200793DD6 /* JOSESwift */,
 			);
 			productName = MyNumberCardAuth;
-			productReference = 9FF1B6F72AAD9EB100793DD6 /* MyNumberCardAuth.app */;
+			productReference = 9FF1B6F22AAD83FF00793DD6 /* MyNumberCardAuth.app */;
 			productType = "com.apple.product-type.application";
 		};
 /* End PBXNativeTarget section */

--- a/iOS/MyNumberCardAuth/MyNumberCardAuth.xcodeproj/project.pbxproj
+++ b/iOS/MyNumberCardAuth/MyNumberCardAuth.xcodeproj/project.pbxproj
@@ -199,9 +199,8 @@
 			);
 			mainGroup = AD80228029F0B402009EA409;
 			packageReferences = (
-				9FF1B6F12AAD83C900793DD6 /* XCRemoteSwiftPackageReference "TRETJapanNFCReader" */,
 			);
-			productRefGroup = AD80228029F0B402009EA409;
+			productRefGroup = AD80228A29F0B402009EA409 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (

--- a/iOS/MyNumberCardAuth/MyNumberCardAuth/Controllers/AuthenticationController.swift
+++ b/iOS/MyNumberCardAuth/MyNumberCardAuth/Controllers/AuthenticationController.swift
@@ -16,7 +16,7 @@ class AuthenticationController: ObservableObject {
     @Published var messageTitle:String = ""
     @Published var messageString:String = ""
     @Published var isErrorOpenURL:Bool = false
-    @Published var nonceHash:String = ""
+    @Published var nonce:String = ""
     @Published var queryDict:[String: String]?
     @Published var openURL:String = ""
     @Published var controller:ViewController = ViewController()

--- a/iOS/MyNumberCardAuth/MyNumberCardAuth/Info.plist
+++ b/iOS/MyNumberCardAuth/MyNumberCardAuth/Info.plist
@@ -2,14 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>AuthenticationPIN_Lower</key>
-	<integer>24</integer>
-	<key>AuthenticationPIN_Upper</key>
-	<integer>0</integer>
-	<key>AuthenticationUertificate_Lower</key>
-	<integer>10</integer>
-	<key>AuthenticationUertificate_Upper</key>
-	<integer>0</integer>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -30,24 +22,8 @@
 	</dict>
 	<key>PrivacyPolicyURL</key>
 	<string>https://example.com/open-id/privacy-policy.html</string>
-	<key>ProofKey_Upper</key>
-	<integer>0</integer>
-	<key>Proofkey_Lower</key>
-	<integer>23</integer>
 	<key>ProtectionPolicyURL</key>
 	<string>https://example.com/open-id/personal-data-protection-policy.html</string>
-	<key>SignaturePIN_Lower</key>
-	<integer>27</integer>
-	<key>SignaturePIN_Upper</key>
-	<integer>0</integer>
-	<key>SigningCertificate_Lower</key>
-	<integer>1</integer>
-	<key>SigningCertificate_Upper</key>
-	<integer>0</integer>
-	<key>SigningKey_Lower</key>
-	<integer>26</integer>
-	<key>SigningKey_Upper</key>
-	<integer>0</integer>
 	<key>TermsOfServiceURL</key>
 	<string>https://example.com/open-id/terms-of-use.html</string>
 	<key>UIApplicationSceneManifest</key>

--- a/iOS/MyNumberCardAuth/MyNumberCardAuth/Info.plist
+++ b/iOS/MyNumberCardAuth/MyNumberCardAuth/Info.plist
@@ -2,6 +2,14 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>AuthenticationPIN_Lower</key>
+	<integer>24</integer>
+	<key>AuthenticationPIN_Upper</key>
+	<integer>0</integer>
+	<key>AuthenticationUertificate_Lower</key>
+	<integer>10</integer>
+	<key>AuthenticationUertificate_Upper</key>
+	<integer>0</integer>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -22,8 +30,24 @@
 	</dict>
 	<key>PrivacyPolicyURL</key>
 	<string>https://example.com/open-id/privacy-policy.html</string>
+	<key>ProofKey_Upper</key>
+	<integer>0</integer>
+	<key>Proofkey_Lower</key>
+	<integer>23</integer>
 	<key>ProtectionPolicyURL</key>
 	<string>https://example.com/open-id/personal-data-protection-policy.html</string>
+	<key>SignaturePIN_Lower</key>
+	<integer>27</integer>
+	<key>SignaturePIN_Upper</key>
+	<integer>0</integer>
+	<key>SigningCertificate_Lower</key>
+	<integer>1</integer>
+	<key>SigningCertificate_Upper</key>
+	<integer>0</integer>
+	<key>SigningKey_Lower</key>
+	<integer>26</integer>
+	<key>SigningKey_Upper</key>
+	<integer>0</integer>
 	<key>TermsOfServiceURL</key>
 	<string>https://example.com/open-id/terms-of-use.html</string>
 	<key>UIApplicationSceneManifest</key>

--- a/iOS/MyNumberCardAuth/MyNumberCardAuth/Models/AuthenticationManager.swift
+++ b/iOS/MyNumberCardAuth/MyNumberCardAuth/Models/AuthenticationManager.swift
@@ -22,6 +22,8 @@ public class AuthenticationManager:IndividualNumberReaderSessionDelegate{
     
     public func authenticateForUserVerification(pin: String, nonce: String, actionURL: String){
         self.actionURL = actionURL
+        self.authenticationController.nonce = nonce
+        self.individualNumberCardExecuteType = .computeDigitalSignature
         self.conputeDigitalSignatureForUserVerification(userAuthenticationPIN: pin, dataToSign: nonce)
     }
     

--- a/iOS/MyNumberCardAuth/MyNumberCardAuth/Models/AuthenticationManager.swift
+++ b/iOS/MyNumberCardAuth/MyNumberCardAuth/Models/AuthenticationManager.swift
@@ -93,7 +93,7 @@ public class AuthenticationManager:IndividualNumberReaderSessionDelegate{
                 
         Task{
             let payload = "{ \"claim\": \"" + digitalCertificate + "\" }"
-            let digitalCertificateJWEEncoded = try? await encryptJWE(from: [UInt8](payload.utf8))
+            let encryptedCertificate = try? await encryptJWE(from: [UInt8](payload.utf8))
             var request = URLRequest(url: URL(string: actionURL)!)
             
             var mode: String = ""
@@ -120,7 +120,7 @@ public class AuthenticationManager:IndividualNumberReaderSessionDelegate{
             request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
             var requestBodyComponents = URLComponents()
             requestBodyComponents.queryItems = [URLQueryItem(name: "mode", value: mode),
-                                                URLQueryItem(name: certificateName, value: digitalCertificateJWEEncoded),
+                                                URLQueryItem(name: certificateName, value: encryptedCertificate),
                                                 URLQueryItem(name: "applicantData", value: self.authenticationController.nonce),
                                                 URLQueryItem(name: "sign", value: digitalSignature)]
             

--- a/iOS/MyNumberCardAuth/MyNumberCardAuth/Models/AuthenticationManager.swift
+++ b/iOS/MyNumberCardAuth/MyNumberCardAuth/Models/AuthenticationManager.swift
@@ -24,7 +24,7 @@ public class AuthenticationManager:IndividualNumberReaderSessionDelegate {
         self.actionURL = actionURL
         self.authenticationController.nonce = nonce
         self.individualNumberCardExecuteType = .computeDigitalSignature
-        self.conputeDigitalSignatureForUserVerification(userAuthenticationPIN: pin, dataToSign: nonce)
+        self.computeDigitalSignatureForUserVerification(userAuthenticationPIN: pin, dataToSign: nonce)
     }
     
     public func authenticateForSignature(pin: String, nonce: String, actionURL: String) {

--- a/iOS/MyNumberCardAuth/MyNumberCardAuth/Models/AuthenticationManager.swift
+++ b/iOS/MyNumberCardAuth/MyNumberCardAuth/Models/AuthenticationManager.swift
@@ -140,12 +140,11 @@ public class AuthenticationManager:IndividualNumberReaderSessionDelegate {
     }
     
     private func encryptJWE(from: [UInt8]) async throws -> String {
-        let pattern = /^https?:\/\/[^\/]+\/realms\/[^\/]+/
-        
         if (self.actionURL == nil) {
             return ""
         }
         
+        let pattern = /^https?:\/\/[^\/]+\/realms\/[^\/]+/
         let rootUrl = try pattern.firstMatch(in: self.actionURL!)!.0
         let strUrl = String(rootUrl)
         let jwksUrl = strUrl + "/protocol/openid-connect/certs"
@@ -156,10 +155,10 @@ public class AuthenticationManager:IndividualNumberReaderSessionDelegate {
         
         for jwk in jwks {
             if (jwk["alg"] == "RSA-OAEP-256") {
-                let jwk: RSAPublicKey = jwk as! RSAPublicKey
+                let rsaPublicKey: RSAPublicKey = jwk as! RSAPublicKey
                 let header = JWEHeader(keyManagementAlgorithm: .RSAOAEP256, contentEncryptionAlgorithm: .A128CBCHS256)
                 let payload = Payload(Data(from))
-                let publicKey: SecKey = try jwk.converted(to: SecKey.self)
+                let publicKey: SecKey = try rsaPublicKey.converted(to: SecKey.self)
                 let encrypter = Encrypter(keyManagementAlgorithm: .RSAOAEP256, contentEncryptionAlgorithm: .A128CBCHS256, encryptionKey: publicKey)!
                 let jwe = try? JWE(header: header, payload: payload, encrypter: encrypter)
                      

--- a/iOS/MyNumberCardAuth/MyNumberCardAuth/Models/AuthenticationManager.swift
+++ b/iOS/MyNumberCardAuth/MyNumberCardAuth/Models/AuthenticationManager.swift
@@ -96,7 +96,7 @@ public class AuthenticationManager:IndividualNumberReaderSessionDelegate{
             let digitalCertificateJWEEncoded = try? await encryptJWE(from: [UInt8](payload.utf8))
             var request = URLRequest(url: URL(string: actionURL)!)
             
-            var mode:String = ""
+            var mode: String = ""
             switch(self.authenticationController.runMode){
             case .Login:
                 mode = "login"
@@ -106,7 +106,7 @@ public class AuthenticationManager:IndividualNumberReaderSessionDelegate{
                 mode = "replacement"
             }
             
-            var certificateName:String = ""
+            var certificateName: String = ""
             switch(self.authenticationController.viewState){
             case .UserVerificationView:
                 certificateName = "encryptedUserAuthenticationCertificate"

--- a/iOS/MyNumberCardAuth/MyNumberCardAuth/Models/AuthenticationManager.swift
+++ b/iOS/MyNumberCardAuth/MyNumberCardAuth/Models/AuthenticationManager.swift
@@ -8,13 +8,14 @@
 import Foundation
 import TRETJapanNFCReader_MIFARE_IndividualNumber
 import CryptoKit
+import JOSESwift
 
 public class AuthenticationManager:IndividualNumberReaderSessionDelegate{
     private var authenticationController:AuthenticationController
     private var individualNumberCardSignatureType: IndividualNumberCardSignatureType?
     private var actionURL: String?
     private var reader: IndividualNumberReaderExtension!
-
+    
     init(authenticationController: AuthenticationController) {
         self.authenticationController = authenticationController
     }
@@ -44,7 +45,11 @@ public class AuthenticationManager:IndividualNumberReaderSessionDelegate{
                let digitalCertificate = individualNumberCardData.digitalSignatureCertificate,
                let actionURL = self.actionURL
             {
-                self.verifySignature(digitalSignature: digitalSignature, digitalCertificate: digitalCertificate, actionURL: actionURL)
+                let digitalSignatureBase64URLEncoded = encodingBase64URL(from: digitalSignature)!
+                let base64DigitalCertificate = Data(digitalCertificate).base64EncodedString()
+                let pemDigitalCertificate = "-----BEGIN CERTIFICATE-----\\n" + base64DigitalCertificate + "\\n-----END CERTIFICATE-----"
+                
+                self.sendVerifySignatureRequest(digitalSignature: digitalSignatureBase64URLEncoded, digitalCertificate: pemDigitalCertificate, actionURL: actionURL)
             }
             break
         case .none:
@@ -75,72 +80,56 @@ public class AuthenticationManager:IndividualNumberReaderSessionDelegate{
     private func computeDigitalCertificateForSignature(signaturePIN: String, dataToSign: String) {
         self.individualNumberCardSignatureType = .digitalSignature
         
-        let data = dataToSign.data(using: .utf8)
-        let nonceStr = (SHA256.hash(data: data!).description)
-        
-        self.authenticationController.nonceHash = String(nonceStr.dropFirst(15))
-
+        self.authenticationController.nonce = dataToSign
         let dataToSignByteArray = [UInt8](dataToSign.utf8)
-        self.reader = IndividualNumberReader(delegate: self)
+        self.reader = IndividualNumberReaderExtension(delegate: self)
         // 以下処理はNFC読み取りが非同期で行われ、完了するとindividualNumberReaderSessionが呼び出される
         self.reader.computeDigitalSignature(signatureType: self.individualNumberCardSignatureType!, pin: signaturePIN, dataToSign: dataToSignByteArray)
     }
-        
-    private func verifySignature(digitalSignature: [UInt8], digitalCertificate: [UInt8], actionURL: String){
-        
-        guard let digitalSignatureBase64URLEncoded = encodingBase64URL(from: digitalSignature) else {
-            return
+    
+    private func sendVerifySignatureRequest(digitalSignature: String, digitalCertificate: String, actionURL: String) {
+                
+        Task{
+            let payload = "{ \"claim\": \"" + digitalCertificate + "\" }"
+            let digitalCertificateJWEEncoded = try? await encryptJWE(from: [UInt8](payload.utf8))
+            var request = URLRequest(url: URL(string: actionURL)!)
+            
+            var mode:String = ""
+            switch(self.authenticationController.runMode){
+            case .Login:
+                mode = "login"
+            case .Registration:
+                mode = "registration"
+            case .Replacement:
+                mode = "replacement"
+            }
+            
+            var certificateName:String = ""
+            switch(self.authenticationController.viewState){
+            case .UserVerificationView:
+                certificateName = "encryptedUserAuthenticationCertificate"
+            case .SignatureView:
+                certificateName = "encryptedDigitalSignatureCertificate"
+            case .ExplanationView:
+                break
+            }
+            
+            request.httpMethod = "POST"
+            request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+            var requestBodyComponents = URLComponents()
+            requestBodyComponents.queryItems = [URLQueryItem(name: "mode", value: mode),
+                                                URLQueryItem(name: certificateName, value: digitalCertificateJWEEncoded),
+                                                URLQueryItem(name: "applicantData", value: self.authenticationController.nonce),
+                                                URLQueryItem(name: "sign", value: digitalSignature)]
+            
+            request.httpBody = requestBodyComponents.query?.data(using: .utf8)
+            
+            let session = HTTPSession(authenticationController: self.authenticationController)
+            session.openRedirectURLOnSafari(request: request)
         }
-        guard let digitalCertificateBase64URLEncoded = encodingBase64URL(from: digitalCertificate) else {
-            return
-        }
-        
-        sendVerifySignatureRequest(signature: digitalSignatureBase64URLEncoded,
-                                   x509File: digitalCertificateBase64URLEncoded, actionURL: actionURL)
     }
     
-    private func sendVerifySignatureRequest(signature: String,x509File: String,actionURL: String){
-        guard let url = URL(string: actionURL) else{
-            return
-        }
-        var request = URLRequest(url: url)
-        
-        var mode:String = ""
-        switch(self.authenticationController.runMode){
-        case .Login:
-            mode = "login"
-        case .Registration:
-            mode = "registration"
-        case .Replacement:
-            mode = "replacement"
-        }
-        
-        var certificate:String = ""
-        switch(self.authenticationController.viewState){
-        case .UserVerificationView:
-            certificate = "userAuthenticationCertificate"
-        case .SignatureView:
-            certificate = "encryptedDigitalSignatureCertificate"
-        case .ExplanationView:
-            break
-        }
-        
-        request.httpMethod = "POST"
-        request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
-        var requestBodyComponents = URLComponents()
-        requestBodyComponents.queryItems = [URLQueryItem(name: "mode", value: mode),
-                                            URLQueryItem(name: certificate, value: x509File),
-                                            URLQueryItem(name: "applicantData", value: self.authenticationController.nonceHash),
-                                            URLQueryItem(name: "sign", value: signature)]
-        
-        request.httpBody = requestBodyComponents.query?.data(using: .utf8)
-        
-        let session = HTTPSession(authenticationController: self.authenticationController)
-        session.openRedirectURLOnSafari(request: request)
-    }
-    
-    
-    private func encodingBase64URL(from: [UInt8]) -> String?{
+    private func encodingBase64URL(from: [UInt8]) -> String? {
         let fromData = Data(from)
         let fromBase64Encoded = fromData.base64EncodedString(options: [])
         let allowedCharacterSet = CharacterSet(charactersIn: "!*'();:@&=+$,/?%#[]").inverted
@@ -148,4 +137,34 @@ public class AuthenticationManager:IndividualNumberReaderSessionDelegate{
         return fromBase64URLEncoded
     }
     
+    private func encryptJWE(from: [UInt8]) async throws -> String {
+        var serializeJWE: String = ""
+        let pattern = /^https?:\/\/[^\/]+\/realms\/[^\/]+/
+        
+        if let actionUrl = self.actionURL{
+            let rootUrl = try pattern.firstMatch(in: actionUrl)!.0
+            let strUrl = String(rootUrl)
+            let jwksUrl = strUrl + "/protocol/openid-connect/certs"
+            
+            let request = URLRequest(url: URL(string: jwksUrl)!)
+            let (data, _) = try await URLSession.shared.data(for: request)
+            let jwks = try JWKSet(data: data)
+            for key in jwks.keys {
+                if let value = key.parameters["alg"]{
+                    if(value == "RSA-OAEP-256"){
+                        let jwk: RSAPublicKey = key as! RSAPublicKey
+                        let header = JWEHeader(keyManagementAlgorithm: .RSAOAEP256, contentEncryptionAlgorithm: .A128CBCHS256)
+                        let payload = Payload(Data(from))
+                        let publicKey: SecKey = try jwk.converted(to: SecKey.self)
+                        let encrypter = Encrypter(keyManagementAlgorithm: .RSAOAEP256, contentEncryptionAlgorithm: .A128CBCHS256, encryptionKey: publicKey)!
+                        let jwe = try? JWE(header: header, payload: payload, encrypter: encrypter)
+                        
+                        serializeJWE = jwe!.compactSerializedString
+                    }
+                }
+            }
+        }
+
+        return serializeJWE
+    }
 }

--- a/iOS/MyNumberCardAuth/MyNumberCardAuth/Models/AuthenticationManager.swift
+++ b/iOS/MyNumberCardAuth/MyNumberCardAuth/Models/AuthenticationManager.swift
@@ -15,7 +15,7 @@ public class AuthenticationManager:IndividualNumberReaderSessionDelegate{
     private var individualNumberCardSignatureType: IndividualNumberCardSignatureType?
     private var actionURL: String?
     private var reader: IndividualNumberReaderExtension!
-    
+
     init(authenticationController: AuthenticationController) {
         self.authenticationController = authenticationController
     }

--- a/iOS/MyNumberCardAuth/MyNumberCardAuth/Models/AuthenticationManager.swift
+++ b/iOS/MyNumberCardAuth/MyNumberCardAuth/Models/AuthenticationManager.swift
@@ -10,7 +10,7 @@ import TRETJapanNFCReader_MIFARE_IndividualNumber
 import CryptoKit
 import JOSESwift
 
-public class AuthenticationManager:IndividualNumberReaderSessionDelegate{
+public class AuthenticationManager:IndividualNumberReaderSessionDelegate {
     private var authenticationController:AuthenticationController
     private var individualNumberCardSignatureType: IndividualNumberCardSignatureType?
     private var actionURL: String?
@@ -20,14 +20,14 @@ public class AuthenticationManager:IndividualNumberReaderSessionDelegate{
         self.authenticationController = authenticationController
     }
     
-    public func authenticateForUserVerification(pin: String, nonce: String, actionURL: String){
+    public func authenticateForUserVerification(pin: String, nonce: String, actionURL: String) {
         self.actionURL = actionURL
         self.authenticationController.nonce = nonce
         self.individualNumberCardExecuteType = .computeDigitalSignature
         self.conputeDigitalSignatureForUserVerification(userAuthenticationPIN: pin, dataToSign: nonce)
     }
     
-    public func authenticateForSignature(pin: String, nonce: String, actionURL: String){
+    public func authenticateForSignature(pin: String, nonce: String, actionURL: String) {
         self.actionURL = actionURL
         self.computeDigitalCertificateForSignature(signaturePIN: pin, dataToSign: nonce)
     }

--- a/iOS/MyNumberCardAuth/MyNumberCardAuth/Models/AuthenticationManager.swift
+++ b/iOS/MyNumberCardAuth/MyNumberCardAuth/Models/AuthenticationManager.swift
@@ -13,7 +13,7 @@ public class AuthenticationManager:IndividualNumberReaderSessionDelegate{
     private var authenticationController:AuthenticationController
     private var individualNumberCardSignatureType: IndividualNumberCardSignatureType?
     private var actionURL: String?
-    private var reader: IndividualNumberReader!
+    private var reader: IndividualNumberReaderExtension!
 
     init(authenticationController: AuthenticationController) {
         self.authenticationController = authenticationController
@@ -64,8 +64,10 @@ public class AuthenticationManager:IndividualNumberReaderSessionDelegate{
         
         self.authenticationController.nonceHash = String(nonceStr.dropFirst(15))
 
-        let dataToSignByteArray = [UInt8](dataToSign.utf8)
-        self.reader = IndividualNumberReader(delegate: self)
+        // generateDigestInfoメソッドでハッシュ化を行なっているが、keycloakのハッシュ化チェックでは
+        // 未ハッシュ判定となるため、下記でハッシュ化したものを使用する
+        let dataToSignByteArray = [UInt8](self.authenticationController.nonceHash.utf8)
+        self.reader = IndividualNumberReaderExtension(delegate: self)
         // 以下処理はNFC読み取りが非同期で行われ、完了するとindividualNumberReaderSessionが呼び出される
         self.reader.computeDigitalSignature(signatureType: self.individualNumberCardSignatureType!, pin: userAuthenticationPIN, dataToSign: dataToSignByteArray)
     }

--- a/iOS/MyNumberCardAuth/MyNumberCardAuth/Models/AuthenticationManager.swift
+++ b/iOS/MyNumberCardAuth/MyNumberCardAuth/Models/AuthenticationManager.swift
@@ -155,10 +155,9 @@ public class AuthenticationManager:IndividualNumberReaderSessionDelegate {
         
         for jwk in jwks {
             if (jwk["alg"] == "RSA-OAEP-256") {
-                let rsaPublicKey: RSAPublicKey = jwk as! RSAPublicKey
                 let header = JWEHeader(keyManagementAlgorithm: .RSAOAEP256, contentEncryptionAlgorithm: .A128CBCHS256)
                 let payload = Payload(Data(from))
-                let publicKey: SecKey = try rsaPublicKey.converted(to: SecKey.self)
+                let publicKey: SecKey = try (jwk as! RSAPublicKey).converted(to: SecKey.self)
                 let encrypter = Encrypter(keyManagementAlgorithm: .RSAOAEP256, contentEncryptionAlgorithm: .A128CBCHS256, encryptionKey: publicKey)!
                 let jwe = try? JWE(header: header, payload: payload, encrypter: encrypter)
                      

--- a/iOS/MyNumberCardAuth/MyNumberCardAuth/Models/AuthenticationManager.swift
+++ b/iOS/MyNumberCardAuth/MyNumberCardAuth/Models/AuthenticationManager.swift
@@ -14,7 +14,7 @@ public class AuthenticationManager:IndividualNumberReaderSessionDelegate {
     private var authenticationController:AuthenticationController
     private var individualNumberCardSignatureType: IndividualNumberCardSignatureType?
     private var actionURL: String?
-    private var reader: IndividualNumberReaderExtension!
+    private var reader: IndividualNumberReader!
 
     init(authenticationController: AuthenticationController) {
         self.authenticationController = authenticationController
@@ -23,12 +23,14 @@ public class AuthenticationManager:IndividualNumberReaderSessionDelegate {
     public func authenticateForUserVerification(pin: String, nonce: String, actionURL: String) {
         self.actionURL = actionURL
         self.authenticationController.nonce = nonce
-        self.individualNumberCardExecuteType = .computeDigitalSignature
+        self.individualNumberCardExecuteType = .computeDigitalSignatureForUserAuthentication
         self.computeDigitalSignatureForUserVerification(userAuthenticationPIN: pin, dataToSign: nonce)
     }
     
     public func authenticateForSignature(pin: String, nonce: String, actionURL: String) {
         self.actionURL = actionURL
+        self.authenticationController.nonce = nonce
+        self.individualNumberCardExecuteType = .computeDigitalSignatureForSignature
         self.computeDigitalCertificateForSignature(signaturePIN: pin, dataToSign: nonce)
     }
     
@@ -84,7 +86,7 @@ public class AuthenticationManager:IndividualNumberReaderSessionDelegate {
         
         self.authenticationController.nonce = dataToSign
         let dataToSignByteArray = [UInt8](dataToSign.utf8)
-        self.reader = IndividualNumberReaderExtension(delegate: self)
+        self.reader = IndividualNumberReader(delegate: self)
         // 以下処理はNFC読み取りが非同期で行われ、完了するとindividualNumberReaderSessionが呼び出される
         self.reader.computeDigitalSignature(signatureType: self.individualNumberCardSignatureType!, pin: signaturePIN, dataToSign: dataToSignByteArray)
     }


### PR DESCRIPTION
以下を対応しています。
・電子証明書のJWE暗号化
・applicantDataの形式を変更(nonceハッシュ→nonce)

※baseは#21を使用しているため、下記を先にマージする必要あり
https://github.com/c-3lab/mynumbercard-idp/pull/21