### PR TITLE
【sampleRP】ログイン後のカード切り替え対応

### DIFF
--- a/backend/examples/sample-rp/package-lock.json
+++ b/backend/examples/sample-rp/package-lock.json
@@ -12,7 +12,8 @@
         "axios": "^1.4.0",
         "ejs": "^3.1.9",
         "express": "^4.18.2",
-        "express-openid-connect": "^2.16.0"
+        "express-openid-connect": "^2.16.0",
+        "express-useragent": "^1.0.15"
       },
       "devDependencies": {
         "nodemon": "^3.0.1"
@@ -684,6 +685,14 @@
       "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/express-useragent": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/express-useragent/-/express-useragent-1.0.15.tgz",
+      "integrity": "sha512-eq5xMiYCYwFPoekffMjvEIk+NWdlQY9Y38OsTyl13IvA728vKT+q/CSERYWzcw93HGBJcIqMIsZC5CZGARPVdg==",
+      "engines": {
+        "node": ">=4.5"
       }
     },
     "node_modules/filelist": {

--- a/backend/examples/sample-rp/package.json
+++ b/backend/examples/sample-rp/package.json
@@ -18,7 +18,8 @@
     "axios": "^1.4.0",
     "ejs": "^3.1.9",
     "express": "^4.18.2",
-    "express-openid-connect": "^2.16.0"
+    "express-openid-connect": "^2.16.0",
+    "express-useragent": "^1.0.15"
   },
   "devDependencies": {
     "nodemon": "^3.0.1"

--- a/backend/examples/sample-rp/public/css/style.css
+++ b/backend/examples/sample-rp/public/css/style.css
@@ -33,7 +33,7 @@ header .assign {
     text-align: right;
 }
 
-header .reset {
+header .replace {
     text-align: right;
 }
 

--- a/backend/examples/sample-rp/public/css/style.css
+++ b/backend/examples/sample-rp/public/css/style.css
@@ -33,6 +33,10 @@ header .assign {
     text-align: right;
 }
 
+header .reset {
+    text-align: right;
+}
+
 #token-info,
 #user-info {
     max-width: 100%;

--- a/backend/examples/sample-rp/server.js
+++ b/backend/examples/sample-rp/server.js
@@ -114,7 +114,7 @@ app.post("/reset", requiresAuth(), async (req, res, next) => {
   try {
     const resetAPIURL =  process.env.KEYCLOAK_URL + "/realms/" + process.env.KEYCLOAK_REALM + "/userinfo-replacement/login" + "?redirect_uri=" + encodeURIComponent(process.env.BASE_URL + "/reset") + "&scope=openid&response_type=code"
 
-    const postRes = await axios({
+    const { headers } = await axios({
       method: 'post',
       url: resetAPIURL,
       headers: {
@@ -130,7 +130,7 @@ app.post("/reset", requiresAuth(), async (req, res, next) => {
       }
     });
     
-    res.redirect(postRes.headers['location'])
+    res.redirect(headers['location'])
   } catch (error) {
     next(error)
   }

--- a/backend/examples/sample-rp/server.js
+++ b/backend/examples/sample-rp/server.js
@@ -110,13 +110,13 @@ app.post("/assign", requiresAuth(), async (req, res, next) => {
   }
 });
 
-app.post("/reset", requiresAuth(), async (req, res, next) => {
+app.post("/replace", requiresAuth(), async (req, res, next) => {
   try {
-    const resetAPIURL =  process.env.KEYCLOAK_URL + "/realms/" + process.env.KEYCLOAK_REALM + "/userinfo-replacement/login" + "?redirect_uri=" + encodeURIComponent(process.env.BASE_URL + "/reset") + "&scope=openid&response_type=code"
+    const replaceAPIURL =  process.env.KEYCLOAK_URL + "/realms/" + process.env.KEYCLOAK_REALM + "/userinfo-replacement/login" + "?redirect_uri=" + encodeURIComponent(process.env.BASE_URL + "/reset") + "&scope=openid&response_type=code"
 
     const { headers } = await axios({
       method: 'post',
-      url: resetAPIURL,
+      url: replaceAPIURL,
       headers: {
         "Content-type": "application/x-www-form-urlencoded",
         "Authorization": "Bearer " + req.oidc.accessToken.access_token,

--- a/backend/examples/sample-rp/server.js
+++ b/backend/examples/sample-rp/server.js
@@ -1,8 +1,10 @@
 const express = require("express");
 const axios = require('axios');
 const { auth, requiresAuth } = require('express-openid-connect')
+const useragent = require('express-useragent');
 
 const app = express();
+app.use(useragent.express());
 app.set('trust proxy', 'uniquelocal');
 app.set("view engine", "ejs");
 app.use(express.static('public'));
@@ -70,6 +72,15 @@ app.get("/", (req, res) => {
   res.render("index", { user: getUser(req) })
 });
 
+app.get("/reset", requiresAuth(), async (req, res, next) => {
+  try {
+    await req.oidc.accessToken.refresh()
+    res.redirect(303, "/")
+  } catch (error) {
+    next(error)
+  }
+});
+
 app.post("/assign", requiresAuth(), async (req, res, next) => {
   try {
     const serviceIdValue = process.env.SERVICE_ID
@@ -94,6 +105,32 @@ app.post("/assign", requiresAuth(), async (req, res, next) => {
 
     await req.oidc.accessToken.refresh()
     res.redirect(303, "/")
+  } catch (error) {
+    next(error)
+  }
+});
+
+app.post("/reset", requiresAuth(), async (req, res, next) => {
+  try {
+    const resetAPIURL =  process.env.KEYCLOAK_URL + "/realms/" + process.env.KEYCLOAK_REALM + "/userinfo-replacement/login" + "?redirect_uri=" + encodeURIComponent(process.env.BASE_URL + "/reset") + "&scope=openid&response_type=code"
+
+    const postRes = await axios({
+      method: 'post',
+      url: resetAPIURL,
+      headers: {
+        "Content-type": "application/x-www-form-urlencoded",
+        "Authorization": "Bearer " + req.oidc.accessToken.access_token,
+        "User-Agent": req.useragent.source
+      },
+      data: {
+      },
+      maxRedirects: 0, 
+      validateStatus: function (status) {
+        return status >= 200 && status <= 302
+      }
+    });
+    
+    res.redirect(postRes.headers['location'])
   } catch (error) {
     next(error)
   }

--- a/backend/examples/sample-rp/server.js
+++ b/backend/examples/sample-rp/server.js
@@ -72,7 +72,7 @@ app.get("/", (req, res) => {
   res.render("index", { user: getUser(req) })
 });
 
-app.get("/reset", requiresAuth(), async (req, res, next) => {
+app.get("/refresh", requiresAuth(), async (req, res, next) => {
   try {
     await req.oidc.accessToken.refresh()
     res.redirect(303, "/")
@@ -112,7 +112,7 @@ app.post("/assign", requiresAuth(), async (req, res, next) => {
 
 app.post("/replace", requiresAuth(), async (req, res, next) => {
   try {
-    const replaceAPIURL =  process.env.KEYCLOAK_URL + "/realms/" + process.env.KEYCLOAK_REALM + "/userinfo-replacement/login" + "?redirect_uri=" + encodeURIComponent(process.env.BASE_URL + "/reset") + "&scope=openid&response_type=code"
+    const replaceAPIURL =  process.env.KEYCLOAK_URL + "/realms/" + process.env.KEYCLOAK_REALM + "/userinfo-replacement/login" + "?redirect_uri=" + encodeURIComponent(process.env.BASE_URL + "/refresh") + "&scope=openid&response_type=code"
 
     const { headers } = await axios({
       method: 'post',
@@ -129,7 +129,7 @@ app.post("/replace", requiresAuth(), async (req, res, next) => {
         return status >= 200 && status <= 302
       }
     });
-    
+
     res.redirect(headers['location'])
   } catch (error) {
     next(error)

--- a/backend/examples/sample-rp/views/index.ejs
+++ b/backend/examples/sample-rp/views/index.ejs
@@ -23,6 +23,11 @@
               <input type="submit" value="RPアサイン">
             </form>
           </div>
+          <div class="reset">
+            <form action="/reset" method="post">
+              <input type="submit" value="カード切り替え">
+            </form>
+          </div>
           <p><a href="/logout">ログアウト</a></p>
         <%_ } _%>
         </header>

--- a/backend/examples/sample-rp/views/index.ejs
+++ b/backend/examples/sample-rp/views/index.ejs
@@ -23,8 +23,8 @@
               <input type="submit" value="RPアサイン">
             </form>
           </div>
-          <div class="reset">
-            <form action="/reset" method="post">
+          <div class="replace">
+            <form action="/replace" method="post">
               <input type="submit" value="カード切り替え">
             </form>
           </div>


### PR DESCRIPTION
以下の対応を実施
・ログイン後のRP画面にカード切り替えボタンを追加し、ボタン押下時にkeycoloakのAPI([https://keycloak.example.com/realms/OIdp/userinfo-replacement/login)を実行しリダイレクトするように修正

keycloakに下記ブランチの対応が必要
https://github.com/c-3lab/mynumbercard-idp/tree/keycloak/feature/userinfo-replacement-by-rest-api