### PR TITLE
【iOS】 外部パッケージのhashを記録しているファイルを追加

### DIFF
--- a/iOS/MyNumberCardAuth/MyNumberCardAuth.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/iOS/MyNumberCardAuth/MyNumberCardAuth.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,23 @@
+{
+  "pins" : [
+    {
+      "identity" : "joseswift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/airsidemobile/JOSESwift.git",
+      "state" : {
+        "revision" : "10ed3b6736def7c26eb87135466b1cb46ea7e37f",
+        "version" : "2.4.0"
+      }
+    },
+    {
+      "identity" : "tretjapannfcreader",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/c-3lab/TRETJapanNFCReader.git",
+      "state" : {
+        "branch" : "ios/fix/lib",
+        "revision" : "c2eefc30d82c3585b6bbf85e656323a24093c626"
+      }
+    }
+  ],
+  "version" : 2
+}


### PR DESCRIPTION
- 本リポジトリの特定のhashを元にビルドした場合、人によって外部パッケージのバージョンを違わないようにするため

このブランチは＃51をベースにしているため、下記マージ後にマージすること
https://github.com/c-3lab/mynumbercard-idp/pull/51