### PR TITLE
【iOS】署名用電子証明書読み取り画面のメッセージ見切れを修正

### DIFF
--- a/iOS/MyNumberCardAuth/MyNumberCardAuth/Views/NFCReadingForSignatureView.swift
+++ b/iOS/MyNumberCardAuth/MyNumberCardAuth/Views/NFCReadingForSignatureView.swift
@@ -25,7 +25,7 @@ struct NFCReadingForSignatureView: View {
                 .font(.title3)
                 .multilineTextAlignment(.center)
                 .padding(/*@START_MENU_TOKEN@*/ .all/*@END_MENU_TOKEN@*/)
-                .frame(height: 140.0)
+                .frame(height: 160.0)
 
             SecureField("password", text: $controller.inputPIN)
                 .padding(.all)


### PR DESCRIPTION
iOSアプリの結合試験にて以下事象が発生したため、修正しております。
事象：
英語版でiOSアプリの署名用電子証明書読み取り画面を表示した際に、画面中のメッセージ末尾が見切れていました。