### PR TITLE
【iOS】URLResposne.allHeaderFieldsのキー値が大文字でも処理できるように対応

### DIFF
--- a/iOS/MyNumberCardAuth/MyNumberCardAuth/Models/HTTPSession.swift
+++ b/iOS/MyNumberCardAuth/MyNumberCardAuth/Models/HTTPSession.swift
@@ -96,8 +96,9 @@ public class HTTPSession: NSObject, URLSessionDelegate, URLSessionTaskDelegate {
 
                 if httpResponse.statusCode == 410 {
                     DispatchQueue.main.async {
-                        if let actionURL = httpResponse.allHeaderFields["x-action-url"] as? String {
-                            self.authenticationController.controllerForSignature.actionURL = actionURL
+                        let keyValues = httpResponse.allHeaderFields.map { (String(describing: $0.key).lowercased(), String(describing: $0.value)) }
+                        if let headerValue = keyValues.filter({ $0.0 == String("X-ACTION-URL").lowercased() }).first {
+                            self.authenticationController.controllerForSignature.actionURL = headerValue.1
                         }
 
                         self.authenticationController.viewState = .SignatureView


### PR DESCRIPTION
ネットワーク環境やサーバーの違いによって、URLResposne.allHeaderFieldsの値が
大文字になるケースがあり、ヘッダーの値が取得できないケースが発生しました。
本PRはキー値が大文字でも小文字でも処理ができるようにiOSアプリを修正したPRになります。