### PR TITLE
新規登録・ログイン画面の修正

### DIFF
--- a/backend/examples/sample-rp/templates/login.html
+++ b/backend/examples/sample-rp/templates/login.html
@@ -39,7 +39,9 @@
             </div>
             <p class="border border-dark border-bottom-0"></p>
         </header>
-
+        <div class="container-fluid">
+            <h3>こちらのSampleRPではマイナンバーカードでログインを行ってからのみ連携を行うことができます</h3>
+        </div>
         <div class="container-fluid">
 
             <div class="row">
@@ -97,24 +99,6 @@
                 </div>
             </div>
         </div>
-
-        <script>
-            // toastクラスがついている要素にBootStrapのトーストを適用する
-            const toastElList = [].slice.call(document.querySelectorAll(".toast"));
-            const toastList = toastElList.map(function (toastEl) {
-                return new bootstrap.Toast(toastEl, {
-                    // オプション
-                    delay: 10000,
-                });
-            });
-            // ボタンをクリックしたときに実行される関数
-            function showToast(num) {
-                // トーストを表示する
-                toastList[num].show();
-            }
-        </script>
-        <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.3/umd/popper.min.js" integrity="sha384-ZMP7rVo3mIykV+2+9J3UJ46jBk0WLaUAdn689aCwoqbBJiSnjAK/l8WvCWPIPm49" crossorigin="anonymous"></script>
-        <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.min.js" integrity="sha384-ChfqqxuZUCnJSK3+MXmPNIyE6ZbWh2IMqE241rYiqJxyMiZ6OW/JmZQ5stwEULTy" crossorigin="anonymous"></script>
+        <script src="{{ url_for('static', filename='script.js') }}"></script>
     </body>
 </html>


### PR DESCRIPTION
・「マイナンバーカードログインを行ってからのみ連携の確認を行える」を伝える文言を追加
・Toast機能が冗長化しているので、Scriptタグを削除
・scriptファイルは「ホーム画面のHTML作成#89」にて記載しているので、こちらではコミットしておりません。