### PR TITLE
add tests for templates (-> index,login,connect,connected,account,token)

### DIFF
--- a/backend/examples/sample-rp/tests/test_app.py
+++ b/backend/examples/sample-rp/tests/test_app.py
@@ -47,10 +47,14 @@ def test_connected(client):
     assert "<title>連携後</title>".encode() in response.data
 
 
-def test_account(client):
-    response = client.get("/account")
-    assert response.status_code == 200
-    assert "<title>アカウント情報照会</title>".encode() in response.data
+def test_account_with_user(client):
+    with client:
+        with client.session_transaction() as sess:
+            sess["user"] = {"name": "test_user"}
+        response = client.get("/account")
+        assert response.status_code == 200
+        assert '<tr><td class="topic bg-primary">お名前</td><td>test_user</td></tr>'.encode() in response.data
+
 
 
 def test_token(client):

--- a/backend/examples/sample-rp/tests/test_app.py
+++ b/backend/examples/sample-rp/tests/test_app.py
@@ -56,6 +56,13 @@ def test_account_with_user(client):
         assert '<tr><td class="topic bg-primary">お名前</td><td>test_user</td></tr>'.encode() in response.data
 
 
+def test_account_without_user(client):
+    with client.session_transaction() as sess:
+        sess["user"] = None
+    response = client.get("/account")
+    assert response.status_code == 200
+    assert '<tr><td class="topic bg-primary">お名前</td><td></td></tr>'.encode() in response.data
+
 
 def test_token(client):
     response = client.get("/token")

--- a/backend/examples/sample-rp/tests/test_app.py
+++ b/backend/examples/sample-rp/tests/test_app.py
@@ -49,20 +49,19 @@ def test_connected(client):
 
 
 def test_account_with_user(client):
-    with client:
-        with client.session_transaction() as sess:
-            sess["user"] = {
-                "name": "test_user",
-                "birth_date": "test_birthdate",
-                "gender_code": "test_gender",
-                "user_address": "test_address",
-            }
-        response = client.get("/account")
-        assert response.status_code == 200
-        assert '<tr><td class="topic bg-primary">お名前</td><td>test_user</td></tr>'.encode() in response.data
-        assert '<tr><td class="topic bg-primary">生年月日</td><td>test_birthdate</td></tr>'.encode() in response.data
-        assert '<tr><td class="topic bg-primary">性別</td><td>test_gender</td></tr>'.encode() in response.data
-        assert '<tr><td class="topic bg-primary">住所</td><td>test_address</td></tr>'.encode() in response.data
+    with client.session_transaction() as sess:
+        sess["user"] = {
+            "name": "test_user",
+            "birth_date": "test_birthdate",
+            "gender_code": "test_gender",
+            "user_address": "test_address",
+        }
+    response = client.get("/account")
+    assert response.status_code == 200
+    assert '<tr><td class="topic bg-primary">お名前</td><td>test_user</td></tr>'.encode() in response.data
+    assert '<tr><td class="topic bg-primary">生年月日</td><td>test_birthdate</td></tr>'.encode() in response.data
+    assert '<tr><td class="topic bg-primary">性別</td><td>test_gender</td></tr>'.encode() in response.data
+    assert '<tr><td class="topic bg-primary">住所</td><td>test_address</td></tr>'.encode() in response.data
 
 
 def test_account_without_user(client):
@@ -74,14 +73,13 @@ def test_account_without_user(client):
 
 
 def test_token_with_user(client):
-    with client:
-        with client.session_transaction() as sess:
-            sess["user"] = {
-                "unique_id": "test_id",
-                "sub": "test_sub",
-                }
-            sess["token"] = {"access_token": "test_access_token"}
-        response = client.get("/token")
+    with client.session_transaction() as sess:
+        sess["user"] = {
+            "unique_id": "test_id",
+            "sub": "test_sub",
+            }
+        sess["token"] = {"access_token": "test_access_token"}
+    response = client.get("/token")
     assert response.status_code == 200
     assert b"<td>test_id</td>" in response.data
     assert b"<td>test_sub</td>" in response.data

--- a/backend/examples/sample-rp/tests/test_app.py
+++ b/backend/examples/sample-rp/tests/test_app.py
@@ -64,9 +64,13 @@ def test_account_without_user(client):
     assert '<tr><td class="topic bg-primary">お名前</td><td></td></tr>'.encode() in response.data
 
 
-def test_token(client):
-    response = client.get("/token")
+def test_token_with_user(client):
+    with client:
+        with client.session_transaction() as sess:
+            sess["user"] = {"unique_id": "test_id"}
+        response = client.get("/token")
     assert response.status_code == 200
-    assert "<title>ID/トークン情報</title>".encode() in response.data
+    assert b"<td>test_id</td>" in response.data
+
 
 

--- a/backend/examples/sample-rp/tests/test_app.py
+++ b/backend/examples/sample-rp/tests/test_app.py
@@ -15,42 +15,47 @@ def client():
 
 def test_index_without_user(client):
     response = client.get("/")
+    assert response.status_code == 200
     assert "新規登録・ログイン".encode() in response.data
 
 
 def test_index_with_user(client):
     with client.session_transaction() as sess:
-        sess['user'] = {'username': 'test_user'}
+        sess["user"] = {"username": "test_user"}
 
     response = client.get('/')
     assert response.status_code == 200
-    assert b'<title>SampleRP Website</title>' in response.data
+    assert b"<title>SampleRP Website</title>" in response.data
     assert "アカウント情報照会".encode() in response.data
-
 
 
 def test_login(client):
     response = client.get("/login")
+    assert response.status_code == 200
     assert "<title>新規会員登録/ログイン</title>".encode() in response.data
 
 
 def test_connect(client):
     response = client.get("/connect")
+    assert response.status_code == 200
     assert "<title>連携前画面</title>".encode() in response.data
 
 
 def test_connected(client):
     response = client.get("/connected")
+    assert response.status_code == 200
     assert "<title>連携後</title>".encode() in response.data
 
 
 def test_account(client):
     response = client.get("/account")
+    assert response.status_code == 200
     assert "<title>アカウント情報照会</title>".encode() in response.data
 
 
 def test_token(client):
     response = client.get("/token")
+    assert response.status_code == 200
     assert "<title>ID/トークン情報</title>".encode() in response.data
 
 

--- a/backend/examples/sample-rp/tests/test_app.py
+++ b/backend/examples/sample-rp/tests/test_app.py
@@ -73,4 +73,9 @@ def test_token_with_user(client):
     assert b"<td>test_id</td>" in response.data
 
 
-
+def test_token_without_user(client):
+    with client.session_transaction() as sess:
+        sess["user"] = None
+    response = client.get("/token")
+    assert response.status_code == 200
+    assert b"<td></td>" in response.data

--- a/backend/examples/sample-rp/tests/test_app.py
+++ b/backend/examples/sample-rp/tests/test_app.py
@@ -1,0 +1,56 @@
+import pytest
+from authlib.integrations.flask_client import OAuth
+
+from app import app
+
+app.config["SECRET_KEY"] = "your_secret_key_for_testing"
+
+oauth: OAuth = OAuth(app)
+
+@pytest.fixture
+def client():
+    app.config['TESTING'] = True
+    return app.test_client()
+
+
+def test_index_without_user(client):
+    response = client.get("/")
+    assert "新規登録・ログイン".encode() in response.data
+
+
+def test_index_with_user(client):
+    with client.session_transaction() as sess:
+        sess['user'] = {'username': 'test_user'}
+
+    response = client.get('/')
+    assert response.status_code == 200
+    assert b'<title>SampleRP Website</title>' in response.data
+    assert "アカウント情報照会".encode() in response.data
+
+
+
+def test_login(client):
+    response = client.get("/login")
+    assert "<title>新規会員登録/ログイン</title>".encode() in response.data
+
+
+def test_connect(client):
+    response = client.get("/connect")
+    assert "<title>連携前画面</title>".encode() in response.data
+
+
+def test_connected(client):
+    response = client.get("/connected")
+    assert "<title>連携後</title>".encode() in response.data
+
+
+def test_account(client):
+    response = client.get("/account")
+    assert "<title>アカウント情報照会</title>".encode() in response.data
+
+
+def test_token(client):
+    response = client.get("/token")
+    assert "<title>ID/トークン情報</title>".encode() in response.data
+
+

--- a/backend/examples/sample-rp/tests/test_app.py
+++ b/backend/examples/sample-rp/tests/test_app.py
@@ -16,16 +16,17 @@ def client():
 def test_index_without_user(client):
     response = client.get("/")
     assert response.status_code == 200
+    assert "ゲスト".encode() in response.data
     assert "新規登録・ログイン".encode() in response.data
 
 
 def test_index_with_user(client):
     with client.session_transaction() as sess:
-        sess["user"] = {"username": "test_user"}
+        sess["user"] = {"name": "test_user"}
 
     response = client.get('/')
     assert response.status_code == 200
-    assert b"<title>SampleRP Website</title>" in response.data
+    assert b"test_user" in response.data
     assert "アカウント情報照会".encode() in response.data
 
 
@@ -50,10 +51,18 @@ def test_connected(client):
 def test_account_with_user(client):
     with client:
         with client.session_transaction() as sess:
-            sess["user"] = {"name": "test_user"}
+            sess["user"] = {
+                "name": "test_user",
+                "birth_date": "test_birthdate",
+                "gender_code": "test_gender",
+                "user_address": "test_address",
+            }
         response = client.get("/account")
         assert response.status_code == 200
         assert '<tr><td class="topic bg-primary">お名前</td><td>test_user</td></tr>'.encode() in response.data
+        assert '<tr><td class="topic bg-primary">生年月日</td><td>test_birthdate</td></tr>'.encode() in response.data
+        assert '<tr><td class="topic bg-primary">性別</td><td>test_gender</td></tr>'.encode() in response.data
+        assert '<tr><td class="topic bg-primary">住所</td><td>test_address</td></tr>'.encode() in response.data
 
 
 def test_account_without_user(client):
@@ -67,10 +76,17 @@ def test_account_without_user(client):
 def test_token_with_user(client):
     with client:
         with client.session_transaction() as sess:
-            sess["user"] = {"unique_id": "test_id"}
+            sess["user"] = {
+                "unique_id": "test_id",
+                "sub": "test_sub",
+                }
+            sess["token"] = {"access_token": "test_access_token"}
         response = client.get("/token")
     assert response.status_code == 200
     assert b"<td>test_id</td>" in response.data
+    assert b"<td>test_sub</td>" in response.data
+    assert b'<td><div class="word-break-all">test_access_token</div></td>' in response.data
+    assert b"user" in response.data
 
 
 def test_token_without_user(client):

--- a/backend/examples/sample-rp/tests/test_app.py
+++ b/backend/examples/sample-rp/tests/test_app.py
@@ -70,6 +70,9 @@ def test_account_without_user(client):
     response = client.get("/account")
     assert response.status_code == 200
     assert '<tr><td class="topic bg-primary">お名前</td><td></td></tr>'.encode() in response.data
+    assert '<tr><td class="topic bg-primary">生年月日</td><td></td></tr>'.encode() in response.data
+    assert '<tr><td class="topic bg-primary">性別</td><td></td></tr>'.encode() in response.data
+    assert '<tr><td class="topic bg-primary">住所</td><td></td></tr>'.encode() in response.data
 
 
 def test_token_with_user(client):
@@ -90,6 +93,10 @@ def test_token_with_user(client):
 def test_token_without_user(client):
     with client.session_transaction() as sess:
         sess["user"] = None
+        sess["token"] = None
     response = client.get("/token")
     assert response.status_code == 200
-    assert b"<td></td>" in response.data
+    assert b"<td></td>" in response.data # assert unique_id
+    assert b"<td></td>" in response.data # assert sub
+    assert b'<td><div class="word-break-all"></div></td>' in response.data
+    assert b" <p>keycloak-id-token: <br>None</p>" in response.data


### PR DESCRIPTION
WEBページの単体テストを行いました。
関数ごとに単体テストを分割し、その一部のPRになります。
単体テストは全部で12個の関数に対して行うつもりです。

- 今回実施した関数
_index,login,connect,connected,account,token_

- 残りの関数
_assign,ketcloak_login,auth,logout,refresh,replace_


**カバレッジについて**
以下の実行コマンドで確認しています。
`pytest --cov=app --cov=tests --cov-branch `

また実行結果のログは以下の通りです。
```
tests/test_app.py ..........                                                                                                [100%]

---------- coverage: platform darwin, python 3.11.4-final-0 ----------
Name                Stmts   Miss Branch BrPart  Cover
-----------------------------------------------------
app.py                 90     44     40      1    55%
tests/__init__.py       0      0      0      0   100%
tests/test_app.py      66      0     16      0   100%
-----------------------------------------------------
TOTAL                 156     44     56      1    72%
```