### PR TITLE
add tests for keycloak_login, refresh

### DIFF
--- a/backend/examples/sample-rp/tests/test_app.py
+++ b/backend/examples/sample-rp/tests/test_app.py
@@ -1,6 +1,4 @@
 import pytest
-from flask.testing import FlaskClient
-from unittest.mock import MagicMock, patch
 from authlib.integrations.flask_client import OAuth
 
 from app import app
@@ -11,7 +9,7 @@ oauth: OAuth = OAuth(app)
 
 
 @pytest.fixture
-def client() -> FlaskClient:
+def client():
     app.config["TESTING"] = True
     return app.test_client()
 
@@ -131,10 +129,11 @@ def test_token_without_user(client):
     assert b" <p>keycloak-id-token: <br>None</p>" in response.data
 
 
-@patch("app.oauth", MagicMock())
-def test_login_keycloak(client: FlaskClient):
-    with patch("app.oauth.keycloak.authorize_redirect") as mock_authorize_redirect:
-        response = client.get("/Keycloak-login")
+@pytest.mark.parametrize("url, expected_status", [("/Keycloak-login", 200)])
+def test_login_keycloak(client, mocker, url, expected_status):
+    mocker.patch("app.oauth")
+    mocker.patch("app.oauth.keycloak.authorize_redirect")
 
-    assert response.status_code == 200
-    assert mock_authorize_redirect.called
+    response = client.get(url)
+
+    assert response.status_code == expected_status

--- a/backend/examples/sample-rp/tests/test_app.py
+++ b/backend/examples/sample-rp/tests/test_app.py
@@ -129,8 +129,10 @@ def test_token_without_user(client):
     assert b" <p>keycloak-id-token: <br>None</p>" in response.data
 
 
-@pytest.mark.parametrize("url, expected_status", [("/Keycloak-login", 200)])
-def test_login_keycloak(client, mocker, url, expected_status):
+def test_login_keycloak(client, mocker):
+    url = "/Keycloak-login"
+    expected_status = 200
+
     oauth_mock = mocker.patch("app.oauth")
     authorize_redirect_mock = oauth_mock.keycloak.authorize_redirect
 


### PR DESCRIPTION
今回実施した関数
key cloak_login, refresh

残りの関数
assign,auth,replace

カバレッジについて
以下の実行コマンドで確認しています。
pytest --cov=app --cov=tests --cov-branch 

また実行結果のログは以下の通りです。
~~~
examples/sample-rp/tests/test_app.py ............                                                                                                                                                                                   [100%]

---------- coverage: platform darwin, python 3.11.5-final-0 ----------
Name                                   Stmts   Miss Branch BrPart  Cover
------------------------------------------------------------------------
examples/sample-rp/app.py                 90     37     40      1    62%
examples/sample-rp/tests/__init__.py       0      0      0      0   100%
examples/sample-rp/tests/test_app.py      93      0     16      0   100%
------------------------------------------------------------------------
TOTAL                                    183     37     56      1    79%
~~~