### PR TITLE
add test for auth and fix missing encode

### DIFF
--- a/backend/examples/sample-rp/tests/test_app.py
+++ b/backend/examples/sample-rp/tests/test_app.py
@@ -112,7 +112,7 @@ def test_token_with_user(client):
     assert "<td>test_id</td>".encode() in response.data
     assert "<td>test_sub</td>".encode() in response.data
     assert (
-        '<td><div class="word-break-all">test_access_token</div></td>' in response.data
+        '<td><div class="word-break-all">test_access_token</div></td>'.encode() in response.data
     )
     assert "user".encode() in response.data
 
@@ -174,4 +174,27 @@ def test_logout(client):
 
     assert response.status_code == 200
     assert "ゲスト".encode() in response.data
+
+
+def test_auth(client, mocker):
+    oauth_mock = mocker.patch("app.oauth")
+    authorize_access_token_mock = oauth_mock.keycloak.authorize_access_token
+    mock_token = {"access_token": "test_access_token", "userinfo": {"name": "test_user"}}
+    mock_userinfo = mock_token["userinfo"]
+    authorize_access_token_mock.return_value = mock_token
+
+    response = client.get("/auth")
+
+    with client.session_transaction() as sess:
+        sess["user"] = mock_userinfo
+        sess["token"] = mock_token
+
+    assert response.status_code == 302
+    assert authorize_access_token_mock.called
+    assert response.location == "/"
+
+    # Check if session information is stored correctly after redirecting to "/"
+    response_after_redirect = client.get(response.location)
+    assert response_after_redirect.status_code == 200
+    assert "test_user".encode() in response_after_redirect.data
 

--- a/backend/examples/sample-rp/tests/test_app.py
+++ b/backend/examples/sample-rp/tests/test_app.py
@@ -176,7 +176,7 @@ def test_logout(client):
     assert "ゲスト".encode() in response.data
 
 
-def test_auth(client, mocker):
+def test_auth_with_user(client, mocker):
     oauth_mock = mocker.patch("app.oauth")
     authorize_access_token_mock = oauth_mock.keycloak.authorize_access_token
     mock_token = {"access_token": "test_access_token", "userinfo": {"name": "test_user"}}
@@ -198,3 +198,25 @@ def test_auth(client, mocker):
     assert response_after_redirect.status_code == 200
     assert "test_user".encode() in response_after_redirect.data
 
+
+def test_auth_without_user(client, mocker):
+    oauth_mock = mocker.patch("app.oauth")
+    authorize_access_token_mock = oauth_mock.keycloak.authorize_access_token
+    mock_token = {"access_token": "test_access_token", "userinfo": None}
+    mock_userinfo = mock_token["userinfo"]
+    authorize_access_token_mock.return_value = mock_token
+
+    response = client.get("/auth")
+
+    with client.session_transaction() as sess:
+        sess["user"] = mock_userinfo
+        sess["token"] = mock_token
+
+    assert response.status_code == 302
+    assert authorize_access_token_mock.called
+    assert response.location == "/"
+
+    # Check if session information is NOT stored correctly after redirecting to "/"
+    response_after_redirect = client.get(response.location)
+    assert response_after_redirect.status_code == 200
+    assert "ゲスト".encode() in response_after_redirect.data


### PR DESCRIPTION
/authの処理を行う際の単体テストを行いました。

- 今回実施した関数
_auth_

- 残りの関数
_assign,replace_

**カバレッジについて**
以下の実行コマンドで確認しています。
`pytest --cov=app --cov=tests --cov-branch `

また実行結果のログは以下の通りです。
```
tests/test_app.py ..............                                                                                                             [100%]

---------- coverage: platform darwin, python 3.11.4-final-0 ----------
Name                Stmts   Miss Branch BrPart  Cover
-----------------------------------------------------
app.py                 90     29     40      2    68%
tests/__init__.py       0      0      0      0   100%
tests/test_app.py     116      0     18      0   100%
-----------------------------------------------------
TOTAL                 206     29     58      2    84%
```