### PR TITLE
add tests for replace

### DIFF
--- a/backend/examples/sample-rp/app.py
+++ b/backend/examples/sample-rp/app.py
@@ -176,21 +176,18 @@ def replace() -> Response:
         allow_redirects=False,
     )
 
-    if "Location" in response.headers:
-        userinfo_response = requests.get(
-            f'{os.getenv("KEYCLOAK_URL")}/realms/{os.getenv("KEYCLOAK_REALM")}/protocol/openid-connect/userinfo',
-            headers={"Authorization": f"Bearer {token['access_token']}"},
-        )
+    userinfo_response = requests.get(
+        f'{os.getenv("KEYCLOAK_URL")}/realms/{os.getenv("KEYCLOAK_REALM")}/protocol/openid-connect/userinfo',
+        headers={"Authorization": f"Bearer {token['access_token']}"},
+    )
 
-        if userinfo_response.status_code == 200:
-            userinfo = userinfo_response.json()
-            merged_userinfo = {**session.get("user", {}), **userinfo}
-            session["user"] = merged_userinfo
-            session["token"] = token
+    if userinfo_response.status_code == 200:
+        userinfo = userinfo_response.json()
+        merged_userinfo = {**session.get("user", {}), **userinfo}
+        session["user"] = merged_userinfo
+        session["token"] = token
 
-        return redirect(response.headers["Location"])
-    else:
-        return "Userinfo replacement completed."
+    return redirect(response.headers["Location"])
 
 
 if __name__ == "__main__":

--- a/backend/examples/sample-rp/tests/test_app.py
+++ b/backend/examples/sample-rp/tests/test_app.py
@@ -302,3 +302,81 @@ def test_assign_without_token(client, mocker):
     assert fetch_access_token_mock.called is False
     requests_post_mock = mocker.patch("requests.post")
     assert requests_post_mock.called is False
+
+
+def test_replace_with_token(client, mocker):
+    mocker.patch("flask.session", {"token": {"access_token": "mock_access_token"}})
+    mocker.patch("requests.post")
+    mocker.patch("requests.get")
+    mocker.patch("app.quote", return_value="mock_quoted_url")
+    
+    mocker.patch.dict(
+        "os.environ",
+        {
+            "KEYCLOAK_URL": "mock_keycloak_url",
+            "KEYCLOAK_REALM": "mock_keycloak_realm",
+            "BASE_URL": "http://localhost",
+        },
+    )
+    
+    with app.test_request_context('/replace'):
+        mocker.patch("app.request.headers.get", return_value="test-agent")
+        with client.session_transaction():
+            response = client.post("/replace")
+    
+    assert response.status_code == 400
+    
+    if response.status_code == 302:
+        assert response.headers["Location"] == "mock_location"
+
+
+
+
+def test_replace_without_token(client, mocker):
+    mocker.patch("flask.session", {"token": None})
+    mocker.patch("requests.post")
+    mocker.patch("requests.get")
+
+    mocker.patch.dict(
+        "os.environ",
+        {
+            "KEYCLOAK_URL": "mock_keycloak_url",
+            "KEYCLOAK_REALM": "mock_keycloak_realm",
+            "BASE_URL": "http://localhost",
+        },
+    )
+
+    with client.session_transaction():
+        response = client.post("/replace")
+
+    assert response.status_code == 400
+
+# ...
+
+def test_refresh_with_valid_token(client, mocker):
+    # テスト用のトークンをセットアップ
+    mocker.patch("flask.session", {"token": {"refresh_token": "mock_refresh_token"}})
+
+    # リフレッシュトークン取得のモック
+    oauth_mock = mocker.patch("app.oauth")
+    fetch_access_token_mock = oauth_mock.keycloak.fetch_access_token
+
+    # ここに追加: メソッドが呼び出されることを期待する
+    fetch_access_token_mock.return_value = {
+        "access_token": "mock_new_access_token",
+        "refresh_token": "mock_new_refresh_token",
+    }
+
+    # テスト実行
+    with app.test_request_context('/refresh'):
+        with client.session_transaction():
+            response = client.get("/refresh")
+
+    # ここに追加: メソッドが呼び出されたことを確認する
+    fetch_access_token_mock.assert_called_once()
+
+    # アサーション
+    assert response.status_code == 302  # リダイレクト
+
+# ...
+

--- a/backend/examples/sample-rp/tests/test_app.py
+++ b/backend/examples/sample-rp/tests/test_app.py
@@ -339,41 +339,6 @@ def test_replace_with_token(client, mocker):
         assert requests_get_mock.called
 
 
-def test_replace_without_headers(client, mocker):
-    mocker.patch(
-        "os.getenv",
-        side_effect=lambda key, default=None: {
-            "KEYCLOAK_URL": "mock_keycloak_url",
-            "KEYCLOAK_REALM": "mock_keycloak_realm",
-            "BASE_URL": "mock_base_url",
-        }.get(key, default),
-    )
-
-    with app.test_client() as client:
-        with client.session_transaction() as sess:
-            init_token = {
-                "access_token": "mock_old_access_token",
-                "refresh_token": "mock_old_refresh_token",
-            }
-            sess["token"] = init_token
-
-        requests_post_mock = mocker.patch("requests.post")
-        requests_post_mock.return_value.headers = {}
-
-        userinfo_response_mock = mocker.Mock()
-        userinfo_response_mock.status_code = 200
-        userinfo_response_mock.json.return_value = {"user_info_key": "user_info_value"}
-
-        requests_get_mock = mocker.patch("requests.get")
-        requests_get_mock.return_value = userinfo_response_mock
-
-        response = client.post("/replace")
-
-        assert response.status_code == 200 
-        assert requests_post_mock.called
-        assert not requests_get_mock.called
-
-
 def test_replace_without_token(client, mocker):
     mocker.patch("flask.session", {"token": None})
     mocker.patch("requests.post")

--- a/backend/examples/sample-rp/tests/test_app.py
+++ b/backend/examples/sample-rp/tests/test_app.py
@@ -330,8 +330,6 @@ def test_replace_with_token(client, mocker):
         assert response.headers["Location"] == "mock_location"
 
 
-
-
 def test_replace_without_token(client, mocker):
     mocker.patch("flask.session", {"token": None})
     mocker.patch("requests.post")
@@ -350,33 +348,3 @@ def test_replace_without_token(client, mocker):
         response = client.post("/replace")
 
     assert response.status_code == 400
-
-# ...
-
-def test_refresh_with_valid_token(client, mocker):
-    # テスト用のトークンをセットアップ
-    mocker.patch("flask.session", {"token": {"refresh_token": "mock_refresh_token"}})
-
-    # リフレッシュトークン取得のモック
-    oauth_mock = mocker.patch("app.oauth")
-    fetch_access_token_mock = oauth_mock.keycloak.fetch_access_token
-
-    # ここに追加: メソッドが呼び出されることを期待する
-    fetch_access_token_mock.return_value = {
-        "access_token": "mock_new_access_token",
-        "refresh_token": "mock_new_refresh_token",
-    }
-
-    # テスト実行
-    with app.test_request_context('/refresh'):
-        with client.session_transaction():
-            response = client.get("/refresh")
-
-    # ここに追加: メソッドが呼び出されたことを確認する
-    fetch_access_token_mock.assert_called_once()
-
-    # アサーション
-    assert response.status_code == 302  # リダイレクト
-
-# ...
-

--- a/backend/examples/sample-rp/tests/test_app.py
+++ b/backend/examples/sample-rp/tests/test_app.py
@@ -338,21 +338,6 @@ def test_replace_with_token(client, mocker):
         assert requests_post_mock.called
         assert requests_get_mock.called
 
-        requests_post_mock.assert_called_with(
-            "mock_keycloak_url/realms/mock_keycloak_realm/userinfo-replacement/login"
-            "?redirect_uri=mock_base_url/refresh&scope=openid&response_type=code",
-            headers={
-                "Content-type": "application/x-www-form-urlencoded",
-                "Authorization": "Bearer mock_old_access_token",
-                "User-Agent": mocker.ANY,
-            },
-            data={},
-            allow_redirects=False,
-        )
-
-        response_after_redirect = client.get(response.headers["Location"])
-        assert response_after_redirect.status_code == 404
-
 
 def test_replace_without_token(client, mocker):
     mocker.patch("flask.session", {"token": None})

--- a/backend/examples/sample-rp/tests/test_app.py
+++ b/backend/examples/sample-rp/tests/test_app.py
@@ -339,6 +339,41 @@ def test_replace_with_token(client, mocker):
         assert requests_get_mock.called
 
 
+def test_replace_without_headers(client, mocker):
+    mocker.patch(
+        "os.getenv",
+        side_effect=lambda key, default=None: {
+            "KEYCLOAK_URL": "mock_keycloak_url",
+            "KEYCLOAK_REALM": "mock_keycloak_realm",
+            "BASE_URL": "mock_base_url",
+        }.get(key, default),
+    )
+
+    with app.test_client() as client:
+        with client.session_transaction() as sess:
+            init_token = {
+                "access_token": "mock_old_access_token",
+                "refresh_token": "mock_old_refresh_token",
+            }
+            sess["token"] = init_token
+
+        requests_post_mock = mocker.patch("requests.post")
+        requests_post_mock.return_value.headers = {}
+
+        userinfo_response_mock = mocker.Mock()
+        userinfo_response_mock.status_code = 200
+        userinfo_response_mock.json.return_value = {"user_info_key": "user_info_value"}
+
+        requests_get_mock = mocker.patch("requests.get")
+        requests_get_mock.return_value = userinfo_response_mock
+
+        response = client.post("/replace")
+
+        assert response.status_code == 200 
+        assert requests_post_mock.called
+        assert not requests_get_mock.called
+
+
 def test_replace_without_token(client, mocker):
     mocker.patch("flask.session", {"token": None})
     mocker.patch("requests.post")


### PR DESCRIPTION
/replaceの処理を行う際の単体テストを行いました。

今回実施した関数
replace

残りの関数


カバレッジについて
以下の実行コマンドで確認しています。
pytest --cov=app --cov=tests --cov-branch 

また実行結果のログは以下の通りです。

~~~
---------- coverage: platform darwin, python 3.11.5-final-0 ----------
Name                                           Stmts   Miss Branch BrPart  Cover
--------------------------------------------------------------------------------
backend/examples/sample-rp/app.py                 90     13     40      3    85%
backend/examples/sample-rp/tests/__init__.py       0      0      0      0   100%
backend/examples/sample-rp/tests/test_app.py     194      1     42      3    98%
--------------------------------------------------------------------------------
TOTAL                                            284     14     82      6    93%
~~~