### PR TITLE
fix test for assign without token

### DIFF
--- a/backend/examples/sample-rp/tests/test_app.py
+++ b/backend/examples/sample-rp/tests/test_app.py
@@ -299,9 +299,41 @@ def test_assign_without_token(client, mocker):
 
     # Assert that the response status code is 400
     assert response.status_code == 400
-    assert fetch_access_token_mock.called is False
+    assert not fetch_access_token_mock.called
     requests_post_mock = mocker.patch("requests.post")
-    assert requests_post_mock.called is False
+    assert not requests_post_mock.called
+
+
+def test_assign_with_token_without_refresh_token(client, mocker):
+    # mock environment variables
+    mocker.patch(
+        "os.getenv",
+        side_effect=lambda key, default=None: {
+            "SERVICE_ID": "mock_service_id",
+            "NOTE": "mock_note",
+            "KEYCLOAK_URL": "mock_keycloak_url",
+            "KEYCLOAK_REALM": "mock_keycloak_realm",
+        }.get(key, default),
+    )
+
+    # mock methods
+    oauth_mock = mocker.patch("app.oauth")
+    fetch_access_token_mock = oauth_mock.keycloak.fetch_access_token
+    fetch_access_token_mock.return_value = {
+        "access_token": "mock_new_access_token",
+        "refresh_token": None,
+    }
+    requests_post_mock = mocker.patch("requests.post")
+
+    with client.session_transaction() as sess:
+        init_token = fetch_access_token_mock.return_value
+        sess["token"] = init_token
+
+    response = client.post("/assign")
+
+    assert response.status_code == 302
+    assert not fetch_access_token_mock.called
+    assert requests_post_mock.called
 
 
 def test_replace_with_token(client, mocker):

--- a/backend/examples/sample-rp/tests/test_app.py
+++ b/backend/examples/sample-rp/tests/test_app.py
@@ -276,32 +276,11 @@ def test_assign_with_token(client, mocker):
 
 
 def test_assign_without_token(client, mocker):
-    # Mock environment variables
-    mocker.patch(
-        "os.getenv",
-        side_effect=lambda key, default=None: {
-            "SERVICE_ID": "mock_service_id",
-            "NOTE": "mock_note",
-            "KEYCLOAK_URL": "mock_keycloak_url",
-            "KEYCLOAK_REALM": "mock_keycloak_realm",
-        }.get(key, default),
-    )
-
-    # Mock methods
-    oauth_mock = mocker.patch("app.oauth")
-    fetch_access_token_mock = oauth_mock.keycloak.fetch_access_token
-    fetch_access_token_mock.return_value = None  # Simulate no token
-
-    requests_post_mock = mocker.patch("requests.post")
-
-    # Perform request without setting token
-    response = client.post("/assign")
-
-    # Assert that the response status code is 400
+    mocker.patch("flask.session", {"token": None})
+    mocker.patch("requests.post")
+    with client.session_transaction():
+        response = client.post("/assign")
     assert response.status_code == 400
-    assert not fetch_access_token_mock.called
-    requests_post_mock = mocker.patch("requests.post")
-    assert not requests_post_mock.called
 
 
 def test_assign_with_token_without_refresh_token(client, mocker):


### PR DESCRIPTION
カバーできていないテストについて、修正して追加いたしました。
具体的に修正したテストは以下の関数です。
* assign

**カバレッジについて**
以下の実行コマンドで確認しています。
`pytest --cov=app --cov=tests --cov-branch `

以下、実行結果になります。

```
tests/test_app.py ....................                                                                                                   [100%]

---------- coverage: platform darwin, python 3.11.4-final-0 ----------
Name                Stmts   Miss Branch BrPart  Cover
-----------------------------------------------------
app.py                 88      1     38      2    98%
tests/__init__.py       0      0      0      0   100%
tests/test_app.py     193      0     40      0   100%
-----------------------------------------------------
TOTAL                 281      1     78      2    99%
```